### PR TITLE
use report filters when requesting report data

### DIFF
--- a/open_gov_puller/open_gov_scraper.py
+++ b/open_gov_puller/open_gov_scraper.py
@@ -138,7 +138,7 @@ class OpenGovScraper:
         if report_metadata:
             payload["categoryID"] = category_id
             payload["recordTypeID"] = report_metadata["recordTypeID"]
-            payload["filters"] = "[]"
+            payload["filters"] = report_metadata["filters"]
             payload["columns"] = report_metadata["columns"]
             payload["reportType"] = report_metadata["reportScopeID"]
             payload["pageNumber"] = 0


### PR DESCRIPTION
use the filters from the report metadata instead of always setting no filters
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use specified filters from report metadata in `generate_report_payload()` in `open_gov_scraper.py` instead of defaulting to no filters.
> 
>   - **Behavior**:
>     - In `generate_report_payload()` in `open_gov_scraper.py`, use `report_metadata["filters"]` instead of an empty list for `payload["filters"]`.
>     - Ensures report data requests use specified filters from metadata instead of no filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fopen_gov_puller&utm_source=github&utm_medium=referral)<sup> for 0c28c82698ada65cac375b7c27996327f3d4642e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->