### PR TITLE
set payload filter to empty list if there are no filters

### DIFF
--- a/open_gov_puller/open_gov_scraper.py
+++ b/open_gov_puller/open_gov_scraper.py
@@ -138,7 +138,7 @@ class OpenGovScraper:
         if report_metadata:
             payload["categoryID"] = category_id
             payload["recordTypeID"] = report_metadata["recordTypeID"]
-            payload["filters"] = report_metadata["filters"]
+            payload["filters"] = report_metadata["filters"] or "[]"
             payload["columns"] = report_metadata["columns"]
             payload["reportType"] = report_metadata["reportScopeID"]
             payload["pageNumber"] = 0


### PR DESCRIPTION
when the filter value in the report metadata is none, set the filter in the payload to "[]"
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `payload["filters"]` to `"[]"` in `generate_report_payload()` if `report_metadata["filters"]` is `None`.
> 
>   - **Behavior**:
>     - In `generate_report_payload()` in `open_gov_scraper.py`, set `payload["filters"]` to `"[]"` if `report_metadata["filters"]` is `None`.
>   - **Misc**:
>     - Ensures payload consistency by handling `None` filter values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fopen_gov_puller&utm_source=github&utm_medium=referral)<sup> for 2206c473444514dcaa4da88dccbcce1e3d7edb77. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->