### PR TITLE
remove headers from output csv

### DIFF
--- a/open_gov_puller/open_gov_scraper.py
+++ b/open_gov_puller/open_gov_scraper.py
@@ -211,8 +211,6 @@ class OpenGovScraper:
                 fieldnames = data[0].keys()
                 writer = csv.DictWriter(csvfile, fieldnames = fieldnames)
 
-                writer.writeheader()
-
                 for record in data:
                     writer.writerow(record)
 


### PR DESCRIPTION
Don't include headers in output csv for swarm.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes header writing from CSV output in `create_csv()` in `open_gov_scraper.py`.
> 
>   - **Behavior**:
>     - Removes header writing in `create_csv()` in `open_gov_scraper.py`, so output CSVs no longer include headers.
>   - **Misc**:
>     - No other changes or impacts on other parts of the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fopen_gov_puller&utm_source=github&utm_medium=referral)<sup> for 35b3c832e020e19b31e43ea5772eb71e0682a4e0. You can [customize](https://app.ellipsis.dev/tolemi-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->