### PR TITLE
allow for login with opengov option

### DIFF
--- a/open_gov_puller/open_gov_scraper.py
+++ b/open_gov_puller/open_gov_scraper.py
@@ -28,11 +28,16 @@ class OpenGovScraper:
         try:
             self.retry_wait_for_selector(url, ".auth0-lock-social-button-text")
             logging.info("Found log in with OpenGov element")
+
+            logging.info("Logging in with OpenGov")
+            self.page.locator(".auth0-lock-social-button-text").click()
         except:
-            print(self.page.content())
-    
-        logging.info("Logging in with OpenGov")
-        self.page.locator(".auth0-lock-social-button-text").click()
+            try:
+                logging.info("Could not find log in with OpenGov element. Looking for email input element.")
+                self.retry_wait_for_selector(url, "input[name='email']")
+                logging.info("Found email input element element")
+            except:
+                print(self.page.content())
 
         self.page.locator("input[name='email']").fill(self.username)
         self.page.locator("xpath=//button[@type='submit']").click()


### PR DESCRIPTION
There are some opengov cities that have a "login with opengov" button on the log in screen and some that do not. This accommodates logging in for either of these options
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `login()` in `open_gov_scraper.py` to support login via email when 'login with OpenGov' button is absent.
> 
>   - **Behavior**:
>     - Updates `login()` in `open_gov_scraper.py` to handle cases where the 'login with OpenGov' button is missing.
>     - Adds fallback to use email input for login if the OpenGov button is not found.
>   - **Logging**:
>     - Adds logging for both successful and fallback login attempts.
>     - Logs error and page content if neither login method is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fopen_gov_puller&utm_source=github&utm_medium=referral)<sup> for 70225c691b976815243fba8f7e97f41a1878e639. You can [customize](https://app.ellipsis.dev/tolemi-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->